### PR TITLE
Backport fix for storage monitor stack size

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeStorageMonitor.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeStorageMonitor.java
@@ -120,7 +120,7 @@ public class NetworkNodeStorageMonitor extends NetworkNode implements IRSFilterC
 
         ItemStack filter = this.config.getItemHandler().getStackInSlot(0);
 
-        int toExtract = player.isSneaking() ? 1 : 64;
+        int toExtract = player.isSneaking() ? 1 : filter.getMaxStackSize();
 
         if (!filter.isEmpty()) {
             ItemStack result = network.extractItem(filter, toExtract, this.config.getCompare(), Action.PERFORM);


### PR DESCRIPTION
This is the exact same change as https://github.com/refinedmods/refinedstorage/commit/5db2177719020f238ff42d598f747d6e687f8c1d. I haven't tested it aside from compiling, but the code is very straightforward and appears identical to 1.16, so I assume this fork has the same issue.