### PR TITLE
Add support for fluidlogging cables like in 1.16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ repositories {
         url 'https://repo.maven.apache.org/maven2'
         name 'Maven Central'
     }
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -107,6 +108,8 @@ dependencies {
 
     compileOnly fg.deobf("li.cil.oc:OpenComputers:MC1.12.2-1.7.2.67:api")
     compileOnly("inventory-tweaks:InventoryTweaks:1.63:api")
+
+    compileOnly fg.deobf('com.github.jbredwards:Fluidlogged-API:5c18d3ff5c')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'

--- a/src/main/java/com/raoulvdberge/refinedstorage/block/BlockCable.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/block/BlockCable.java
@@ -18,6 +18,7 @@ import com.raoulvdberge.refinedstorage.tile.TileBase;
 import com.raoulvdberge.refinedstorage.tile.TileCable;
 import com.raoulvdberge.refinedstorage.tile.TileNode;
 import com.raoulvdberge.refinedstorage.util.CollisionUtils;
+import git.jbredwards.fluidlogged_api.api.block.IFluidloggable;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyBool;
@@ -33,6 +34,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.property.IExtendedBlockState;
+import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -40,7 +42,8 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BlockCable extends BlockNode {
+@Optional.Interface(iface = "git.jbredwards.fluidlogged_api.api.block.IFluidloggable", modid = "fluidlogged_api")
+public class BlockCable extends BlockNode implements IFluidloggable {
     public static final PropertyObject<Cover> COVER_NORTH = new PropertyObject<>("cover_north", Cover.class);
     public static final PropertyObject<Cover> COVER_EAST = new PropertyObject<>("cover_east", Cover.class);
     public static final PropertyObject<Cover> COVER_SOUTH = new PropertyObject<>("cover_south", Cover.class);


### PR DESCRIPTION
This is waiting on https://github.com/jbredwards/Fluidlogged-API/issues/63 so we don't need to keep a `stable_39` JAR in the repo.